### PR TITLE
Optimize Auto Defuse Lua

### DIFF
--- a/CS2 Auto Defuse.lua
+++ b/CS2 Auto Defuse.lua
@@ -1,78 +1,32 @@
-local guiEnabled = gui.Checkbox(gui.Reference("Misc", "General", "Extra"), "autodefuse", "Auto-Defuse", false);
-guiEnabled:SetDescription("Defuses the bomb right before time runs out.");
+local guiEnabled = gui.Checkbox(gui.Reference("Misc", "General", "Extra"), "autodefuse", "Auto-Defuse", false)
+guiEnabled:SetDescription("Defuses the bomb right before time runs out.")
 
-local g_bIsDefusing = false;
+local IN_USE = bit.lshift(1, 5)
+callbacks.Register("CreateMove", function(pCmd)
+    if not pCmd then return end
 
-local function StopDefusing()
-    if g_bIsDefusing then
-        client.Command("-use");
-        g_bIsDefusing = false;
-    end
-end
+    if not guiEnabled:GetValue() then return end
 
-callbacks.Register("Draw", function()
-    if not guiEnabled:GetValue() then
-        return StopDefusing();
-    end
+    local pLocal = entities.GetLocalPlayer()
+    if not pLocal or not pLocal:IsAlive() or pLocal:GetTeamNumber() ~= 3 then return end
 
-    local pLocalPlayer = entities.GetLocalPlayer();
-    if not pLocalPlayer then
-        return StopDefusing();
-    end
-
-    if not pLocalPlayer:IsAlive() or pLocalPlayer:GetTeamNumber() ~= 3 then
-        return StopDefusing();
-    end
-
-    local iLocalIndex = pLocalPlayer:GetIndex();
-    local pLocalPlayerController = nil;
-    for _, pEnt in pairs(entities.FindByClass("CCSPlayerController")) do
-        local pPawn = pEnt:GetPropEntity("m_hPlayerPawn");
-
-        if pPawn:GetIndex() == iLocalIndex then
-            pLocalPlayerController = pEnt;
-            break;
-        end
-    end
-
-    if not pLocalPlayerController then
-        return StopDefusing();
-    end
+    local pLocalPlayerController = nil
+    if (pLocal:GetPropInt("m_hOriginalController") > 0) then pLocalPlayerController = pLocal:GetPropEntity("m_hOriginalController") end
+    if not pLocalPlayerController then return end
 
     local pBomb = nil
-    for _, pEnt in pairs(entities.FindByClass("C_PlantedC4")) do
-        if pEnt:GetPropBool("m_bBombTicking") then
-            pBomb = pEnt;
-        end
-    end
+    for _, pEnt in pairs(entities.FindByClass("C_PlantedC4")) do if pEnt:GetPropBool("m_bBombTicking") then pBomb = pEnt end end
+    if not pBomb then return end
+    if (pBomb:GetAbsOrigin() - pLocal:GetAbsOrigin()):Length() > 65 then return end
 
-    if not pBomb then
-        return StopDefusing();
-    end
+    local pBombDefuser = nil
+    if (pBomb:GetPropInt("m_pBombDefuser") > 0) then pBombDefuser = pBomb:GetPropEntity("m_pBombDefuser") end
+    if pBombDefuser and pBombDefuser:GetIndex() ~= pLocal:GetIndex() then return end
 
-    if pLocalPlayerController:GetClass() ~= "CCSPlayerController" or pBomb:GetClass() ~= "C_PlantedC4" then
-        return StopDefusing();
-    end
+    local flDefuseLength = (pLocalPlayerController:GetPropBool("m_bPawnHasDefuser") and 5 or 10)
+    local flTimeUntilDefuse = pBomb:GetPropFloat("m_flC4Blow") - globals.CurTime() - flDefuseLength
+    flTimeUntilDefuse = flTimeUntilDefuse - (globals.FrameTime() + 0.015625 + (pLocalPlayerController:GetPropInt("m_iPing") * 2 / 1000))
+    if flTimeUntilDefuse > 0 then return end
 
-    if (pBomb:GetPropBool("m_bBeingDefused") and not g_bIsDefusing) or (pBomb:GetAbsOrigin() - pLocalPlayer:GetAbsOrigin()):Length() > 65 then
-        return StopDefusing();
-    end
-
-    if g_bIsDefusing then
-        return;
-    end
-
-    local flRemainingBombTime = pBomb:GetPropFloat("m_flC4Blow") - globals.CurTime() - (pLocalPlayerController:GetPropBool("m_bPawnHasDefuser") and 5 or 10);
-    flRemainingBombTime = flRemainingBombTime - (globals.FrameTime() + 0.015625 + (pLocalPlayerController:GetPropInt("m_iPing") * 2 / 1000));
-
-    if flRemainingBombTime < 0 or flRemainingBombTime > math.max(0.01, globals.FrameTime()) then
-        return StopDefusing();
-    end
-
-    client.Command("+use");
-    g_bIsDefusing = true;
-end)
-
-callbacks.Register("Unload", function()
-    StopDefusing();
+    pCmd:SetButtons(pCmd:GetButtons() + IN_USE)
 end)

--- a/CS2 Auto Defuse.lua
+++ b/CS2 Auto Defuse.lua
@@ -1,32 +1,74 @@
-local guiEnabled = gui.Checkbox(gui.Reference("Misc", "General", "Extra"), "autodefuse", "Auto-Defuse", false)
-guiEnabled:SetDescription("Defuses the bomb right before time runs out.")
+local guiEnabled = gui.Checkbox(gui.Reference("Misc", "General", "Extra"), "autodefuse", "Auto-Defuse", false);
+guiEnabled:SetDescription("Defuses the bomb right before time runs out.");
 
-local IN_USE = bit.lshift(1, 5)
-callbacks.Register("CreateMove", function(pCmd)
-    if not pCmd then return end
+local g_bIsDefusing = false;
+local function StopDefusing()
+    if g_bIsDefusing then
+        client.Command("-use");
+        g_bIsDefusing = false;
+    end
+end
 
-    if not guiEnabled:GetValue() then return end
+callbacks.Register("Draw", function()
+    if(not guiEnabled:GetValue())then
+        StopDefusing();
+        return;
+    end
 
-    local pLocal = entities.GetLocalPlayer()
-    if not pLocal or not pLocal:IsAlive() or pLocal:GetTeamNumber() ~= 3 then return end
+    local pLocalPlayer = entities.GetLocalPlayer();
+    if(not pLocalPlayer)then
+        StopDefusing();
+        return;
+    end
 
-    local pLocalPlayerController = nil
-    if (pLocal:GetPropInt("m_hOriginalController") > 0) then pLocalPlayerController = pLocal:GetPropEntity("m_hOriginalController") end
-    if not pLocalPlayerController then return end
+    -- If we are not alive, not on the counter-terrorist team, or our original controller handle is invalid
+    if(not pLocalPlayer:IsAlive() or pLocalPlayer:GetTeamNumber() ~= 3 or pLocalPlayer:GetPropInt("m_hOriginalController") <= 0)then
+        StopDefusing();
+        return;
+    end
 
-    local pBomb = nil
-    for _, pEnt in pairs(entities.FindByClass("C_PlantedC4")) do if pEnt:GetPropBool("m_bBombTicking") then pBomb = pEnt end end
-    if not pBomb then return end
-    if (pBomb:GetAbsOrigin() - pLocal:GetAbsOrigin()):Length() > 65 then return end
+    -- Find an active bomb
+    local pBomb;
+    for _, pEnt in pairs(entities.FindByClass("C_PlantedC4")) do
+        if(pEnt:GetPropBool("m_bBombTicking"))then
+            pBomb = pEnt;
+            break;
+        end
+    end
 
-    local pBombDefuser = nil
-    if (pBomb:GetPropInt("m_pBombDefuser") > 0) then pBombDefuser = pBomb:GetPropEntity("m_pBombDefuser") end
-    if pBombDefuser and pBombDefuser:GetIndex() ~= pLocal:GetIndex() then return end
+    if(not pBomb)then
+        StopDefusing();
+        return;
+    end
 
-    local flDefuseLength = (pLocalPlayerController:GetPropBool("m_bPawnHasDefuser") and 5 or 10)
-    local flTimeUntilDefuse = pBomb:GetPropFloat("m_flC4Blow") - globals.CurTime() - flDefuseLength
-    flTimeUntilDefuse = flTimeUntilDefuse - (globals.FrameTime() + 0.015625 + (pLocalPlayerController:GetPropInt("m_iPing") * 2 / 1000))
-    if flTimeUntilDefuse > 0 then return end
+    local pLocalPlayerController = pLocalPlayer:GetPropEntity("m_hOriginalController");
+    if(not pLocalPlayerController)then
+        StopDefusing();
+        return;
+    end
 
-    pCmd:SetButtons(pCmd:GetButtons() + IN_USE)
+    -- If the bomb is being defused but not by us, we are not close enough to the bomb, or we are already defusing
+    if((pBomb:GetPropBool("m_bBeingDefused") and not g_bIsDefusing) or (pBomb:GetAbsOrigin() - pLocalPlayer:GetAbsOrigin()):Length() > 65 or g_bIsDefusing)then
+        StopDefusing();
+        return;
+    end
+
+    -- Remaining time until we HAVE to start defusing the bomb
+    local flRemainingBombTime = pBomb:GetPropFloat("m_flC4Blow") - globals.CurTime() - (pLocalPlayerController:GetPropBool("m_bPawnHasDefuser") and 5 or 10);
+    -- Ugly hack to compensate for latency
+    flRemainingBombTime = flRemainingBombTime - (globals.FrameTime() + 0.015625 + (pLocalPlayerController:GetPropInt("m_iPing") * 2 / 1000));
+
+    -- If we dont have any more time or we still have more than a frame that we can wait 
+    if(flRemainingBombTime < 0 or flRemainingBombTime > math.max(0.01, globlas.FrameTime()))then
+        StopDefusing();
+        return;
+    end
+
+    -- Start defusing
+    client.Command("+use");
+    g_bIsDefusing = true;
+end)
+
+callbacks.Register("Unload", function()
+    StopDefusing();
 end)


### PR DESCRIPTION
Made the code optimized by using CreateMove buttons instead of Draw and executing commands.
Adding GetPropInt before getting the entity in the code should avoid any null entity crashes.
Feel free to edit this towards your coding style or improve it!